### PR TITLE
fix(auth): playground 403 error 수정

### DIFF
--- a/src/main/java/com/github/org/todaybread/todaybread/auth/infra/filter/AuthFilter.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/auth/infra/filter/AuthFilter.java
@@ -8,7 +8,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -34,10 +33,6 @@ public class AuthFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token) && tokenProvider.validation(token)) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        } else if (StringUtils.hasText(token)) {
-            response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        } else {
-            response.setStatus(HttpStatus.FORBIDDEN.value());
         }
         filterChain.doFilter(request, response);
     }


### PR DESCRIPTION
# Fix

- 유효한 접근에서도 401 혹은 403 에러를 발생시키는 `AuthFilter`의 오류를 수정했어요.