### PR TITLE
fix(member): member response에 누락된 name field 추가

### DIFF
--- a/src/main/java/com/github/org/todaybread/todaybread/member/infra/http/response/MemberResponse.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/member/infra/http/response/MemberResponse.java
@@ -23,6 +23,7 @@ public class MemberResponse {
         this.id = member.getId().toString();
         this.createdAt = member.getCreatedAt().toString();
         this.updatedAt = member.getUpdatedAt().toString();
+        this.name = member.getName();
         this.phone = member.getPhone();
         this.email = member.getEmail();
         this.address = member.getAddress();


### PR DESCRIPTION
# Fix
- `member response`에서 누락된 `name` filed를 추가했어요.