### PR TITLE
refactor(review): product에 score 추가

### DIFF
--- a/src/main/java/com/github/org/todaybread/todaybread/product/domain/Product.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/product/domain/Product.java
@@ -53,6 +53,9 @@ public class Product extends Core {
 
     private Integer quantity;
 
+    private Float score = 0.0F;
+
+
     @Builder
     public Product(
         Integer steppayId,
@@ -113,6 +116,12 @@ public class Product extends Core {
 
     public Product updateQuantity(Integer quantity) {
         this.quantity = quantity;
+
+        return this;
+    }
+
+    public Product updateScore(Float score) {
+        this.score = score;
 
         return this;
     }

--- a/src/main/java/com/github/org/todaybread/todaybread/product/infra/http/response/ProductResponse.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/product/infra/http/response/ProductResponse.java
@@ -24,6 +24,8 @@ public class ProductResponse {
     Integer price;
     Integer quantity;
 
+    Float score;
+
     @Builder
     public ProductResponse(Product product) {
         this.id = product.getId().toString();
@@ -42,5 +44,6 @@ public class ProductResponse {
         this.breadType = product.getBreadType();
         this.price = product.getPrice();
         this.quantity = product.getQuantity();
+        this.score = product.getScore();
     }
 }

--- a/src/main/java/com/github/org/todaybread/todaybread/review/application/facade/ReviewFacadeImpl.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/application/facade/ReviewFacadeImpl.java
@@ -50,6 +50,9 @@ public class ReviewFacadeImpl implements ReviewFacade {
                 .score(request.getScore())
                 .build()
         );
+        product.updateScore(
+            reviewService.getScoreByProduct(product)
+        );
 
         if (request.getImages() != null) {
             List<File> files = fileFacade.uploads(
@@ -92,6 +95,9 @@ public class ReviewFacadeImpl implements ReviewFacade {
             throw new NotWriterException();
         }
         reviewService.delete(review);
+        review.getProduct().updateScore(
+            reviewService.getScoreByProduct(review.getProduct())
+        );
         return true;
     }
 

--- a/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewService.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewService.java
@@ -12,5 +12,7 @@ public interface ReviewService {
     
     Page<Review> getByProduct(Product product, int page, int take);
 
+    Float getScoreByProduct(Product product);
+
     void delete(Review review);
 }

--- a/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewServiceImpl.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewServiceImpl.java
@@ -36,6 +36,11 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    public Float getScoreByProduct(Product product) {
+        return reviewRepository.getScoreByScore(product);
+    }
+
+    @Override
     @Transactional
     public void delete(Review review) {
         reviewRepository.delete(review);

--- a/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewServiceImpl.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/application/service/ReviewServiceImpl.java
@@ -37,7 +37,7 @@ public class ReviewServiceImpl implements ReviewService {
 
     @Override
     public Float getScoreByProduct(Product product) {
-        return reviewRepository.getScoreByScore(product);
+        return reviewRepository.getScoreByProduct(product);
     }
 
     @Override

--- a/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepository.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepository.java
@@ -14,7 +14,7 @@ public interface ReviewRepository {
 
     Page<Review> getByProduct(Product product, Pageable pageable);
 
-    Float getScoreByScore(Product product);
+    Float getScoreByProduct(Product product);
 
     void delete(Review review);
 }

--- a/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepository.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepository.java
@@ -14,5 +14,7 @@ public interface ReviewRepository {
 
     Page<Review> getByProduct(Product product, Pageable pageable);
 
+    Float getScoreByScore(Product product);
+
     void delete(Review review);
 }

--- a/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepositoryImpl.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.github.org.todaybread.todaybread.review.infra.persistence;
 
 import com.github.org.todaybread.todaybread.product.domain.Product;
+import com.github.org.todaybread.todaybread.review.domain.QReview;
 import com.github.org.todaybread.todaybread.review.domain.Review;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,8 @@ import org.springframework.stereotype.Repository;
 public class ReviewRepositoryImpl implements ReviewRepository {
 
     private final ReviewJpaRepository reviewRepository;
+    private final JPAQueryFactory queryFactory;
+    private final QReview review = QReview.review;
 
     @Override
     public Review save(Review review) {
@@ -28,6 +32,17 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     @Override
     public Page<Review> getByProduct(Product product, Pageable pageable) {
         return reviewRepository.findByProduct(product, pageable);
+    }
+
+    @Override
+    public Float getScoreByScore(Product product) {
+        return queryFactory
+            .select(review.score.avg().floatValue())
+            .from(review)
+            .where(
+                review.product.eq(product)
+            )
+            .fetchOne();
     }
 
     @Override

--- a/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepositoryImpl.java
+++ b/src/main/java/com/github/org/todaybread/todaybread/review/infra/persistence/ReviewRepositoryImpl.java
@@ -35,7 +35,7 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     }
 
     @Override
-    public Float getScoreByScore(Product product) {
+    public Float getScoreByProduct(Product product) {
         return queryFactory
             .select(review.score.avg().floatValue())
             .from(review)

--- a/src/main/resources/graphql/auth.graphqls
+++ b/src/main/resources/graphql/auth.graphqls
@@ -10,7 +10,9 @@ input SignUpRequest {
     name: String!
     email: String!
     phone: String!
-    address: String!
+    postcode: String!
+    address1: String!
+    address2: String!
     profileImage: Upload
 }
 

--- a/src/main/resources/graphql/member.graphqls
+++ b/src/main/resources/graphql/member.graphqls
@@ -6,6 +6,8 @@ type Member {
     name: String!
     phone: String!
     email: String!
-    address: String!
+    postcode: String!
+    address1: String!
+    address2: String!
     profileImageUrl: String
 }

--- a/src/main/resources/graphql/product.graphqls
+++ b/src/main/resources/graphql/product.graphqls
@@ -45,4 +45,5 @@ type Product {
     breadType: BreadType!
     price: Int!
     quantity: Int
+    score: Float!
 }

--- a/src/test/java/com/github/org/todaybread/todaybread/review/application/facade/ReviewFacadeImplTest.java
+++ b/src/test/java/com/github/org/todaybread/todaybread/review/application/facade/ReviewFacadeImplTest.java
@@ -192,4 +192,62 @@ class ReviewFacadeImplTest {
         Boolean response = reviewFacade.delete(memberId, review.getId());
         assertThat(response).isTrue();
     }
+
+    @Test
+    @DisplayName("리뷰를 생성하면 패키지 스코어를 업데이트 할 수 있어요.")
+    public void createReviewWithScore() {
+        reviewFacade.create(memberId, CreateReviewRequest.builder()
+            .productId(productId)
+            .content("test_content")
+            .score(2.0F)
+            .build());
+
+        Float avgExpect2 = productFacade.getById(productId).getScore();
+        assertThat(avgExpect2).isEqualTo(2.0F);
+
+        reviewFacade.create(memberId, CreateReviewRequest.builder()
+            .productId(productId)
+            .content("test_content")
+            .score(4.0F)
+            .build());
+
+        Float avgExpect3 = productFacade.getById(productId).getScore();
+        assertThat(avgExpect3).isEqualTo(3.0F);
+    }
+
+    @Test
+    @DisplayName("리뷰를 삭제하면 패키지 스코어를 업데이트 할 수 있어요.")
+    public void deleteReviewWithScore() {
+        reviewFacade.create(memberId, CreateReviewRequest.builder()
+            .productId(productId)
+            .content("test_content")
+            .score(1.0F)
+            .build());
+
+        Float avgExpect1 = productFacade.getById(productId).getScore();
+        assertThat(avgExpect1).isEqualTo(1.0F);
+
+        reviewFacade.create(memberId, CreateReviewRequest.builder()
+            .productId(productId)
+            .content("test_content")
+            .score(3.0F)
+            .build());
+
+        Float avgExpect2 = productFacade.getById(productId).getScore();
+        assertThat(avgExpect2).isEqualTo(2.0F);
+
+        ReviewResponse review = reviewFacade.create(memberId, CreateReviewRequest.builder()
+            .productId(productId)
+            .content("test_content")
+            .score(5.0F)
+            .build());
+
+        Float avgExpect3 = productFacade.getById(productId).getScore();
+        assertThat(avgExpect3).isEqualTo(3.0F);
+
+        reviewFacade.delete(memberId, review.getId());
+
+        Float deletedReview = productFacade.getById(productId).getScore();
+        assertThat(deletedReview).isEqualTo(2.0F);
+    }
 }


### PR DESCRIPTION
### Refactor/review
- product에 score를 추가했어요. 

매번 product의 review를 조회해 score의 평균을 구하는 쿼리를 보내기엔 성능에 문제가 갈 것 같았어요! (특히 product list 조회할 때 n+1이 발생할 거라고 생각해요.)
product에 score 필드를 추가하고 리뷰가 생성되거나 삭제 될 때마다, product의 review score 평균을 구해 업데이트 해주는 방식을 채택했어요.
score에 대한 강한 무결성을 제공하지 않아도, 주문에 큰 영향을 줄 거같지 않다고 생각해 약한 무결성을 따르기로 결정했습니다.